### PR TITLE
Restore Todoist-to-Notion sync and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # Todoist to Notion Sync
 
 ## Overview
-This Google Cloud Function syncs projects from Todoist to a specified Notion database. It is a one-way synchronization: new projects in Todoist are added to Notion. Existing projects are identified by their name to prevent duplicates.
+This Google Cloud Function syncs projects from Todoist to a specified Notion database. It is a one-way synchronization: new projects in Todoist are added to Notion. Existing projects are identified by their **Todoist Project ID** to prevent duplicates and allow for updates.
 
 ## Features
-- Fetches all active projects from your Todoist account.
-- Creates new projects in Notion if they don't already exist (matched by Todoist Project ID).
-- Updates existing projects in Notion if changes are detected in Todoist (e.g., project name). The "Last Synced" timestamp and description are updated.
-- Stores a "Todoist ID" in a dedicated property in Notion for reliable matching.
-- Each Notion page includes the project name, a "Todoist" source tag, a description referencing the Todoist Project ID, the Todoist ID itself, and a "Last Synced" timestamp.
+- Fetches all active projects from your Todoist account using the REST API.
+- Creates new pages in Notion if a corresponding Todoist Project ID is not found in the database.
+- Updates existing Notion pages if changes are detected in the corresponding Todoist project (currently, the project name).
+- The "Last Synced" timestamp on the Notion page is updated upon every successful sync of the project.
+- A "Description" field in Notion is populated with a generated string containing the Todoist Project's comment count and its ID (e.g., "Contains 5 comments. Todoist Project ID: 123456789.").
+- Stores a unique "Todoist ID" (Rich Text property) in Notion for reliable matching between Todoist projects and Notion pages.
+- Each Notion page includes the project "Name" (Title), a "Source" (Select property set to "Todoist"), the generated "Description", the "Todoist ID", and the "Last Synced" (Date) timestamp.
+- Securely accesses API keys (Todoist, Notion) and Notion Database ID from Google Secret Manager using the `GCP_PROJECT` environment variable to construct secret paths.
 - Logs operations, errors, and informational messages to Google Cloud Logging for monitoring and troubleshooting.
 - HTTP-triggered for easy invocation via URL, Cloud Scheduler, or other services.
 
 ## Prerequisites
-- Python 3.9+
+- Python 3.11+
 - A Google Cloud Platform (GCP) project with billing enabled.
 - A Todoist account with an API token.
 - A Notion account with an integration token and a database created for project syncing.
@@ -28,13 +31,15 @@ cd <repository-directory>
 Replace `<repository-url>` with the actual URL of this repository.
 
 ### 2. Install Dependencies
-Ensure you have Python 3.9+ installed. Then, install the required Python packages:
+Ensure you have Python 3.11+ installed. Then, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
 
-### 3. Environment Variables
--   `GCP_PROJECT`: Your Google Cloud Project ID. The function attempts to automatically determine this when deployed on Google Cloud. For local development, you might need to set this environment variable.
+### 3. Environment Variables for the Cloud Function
+-   `GCP_PROJECT`: Your Google Cloud Project ID. This environment variable **must be set** for the deployed Cloud Function. It is used by the function to construct the full path to the secrets in Google Secret Manager.
+
+For local development, you would also need to set this environment variable and ensure your local environment is authenticated with GCP (e.g., via `gcloud auth application-default login`) with permissions to access the secrets.
 
 ### 4. Google Secret Manager
 This function relies on Google Secret Manager to securely store API keys and other sensitive information. You must create the following secrets in your GCP project:
@@ -49,16 +54,16 @@ This function relies on Google Secret Manager to securely store API keys and oth
         2.  The URL will look something like: `https://www.notion.so/your-workspace/DATABASE_ID?v=VIEW_ID`
         3.  The `DATABASE_ID` is a 32-character alphanumeric string. Copy this value without any hyphens.
 
-**Important**: The service account used by your Google Cloud Function must have the "Secret Manager Secret Accessor" IAM role (`roles/secretmanager.secretAccessor`) to access these secrets.
+**Important**: The service account used by your Google Cloud Function must have the "Secret Manager Secret Accessor" IAM role (`roles/secretmanager.secretAccessor`) on these secrets (or on the project/folder containing them) to access their values.
 
 ### 5. Notion Database Setup
 Your Notion database must be configured with the following properties:
 
 -   **`Name`**: This must be a **Title** property. It will store the name of the Todoist project.
 -   **`Source`**: This must be a **Select** property. Create an option named "Todoist" within this property's settings. The function will automatically set this value for new projects.
--   **`Description`**: This must be a **Rich Text** property. It will store a brief description, including a reference to the original Todoist Project ID.
--   **`Todoist ID`**: This must be a **Rich Text** property (alternatively, a Text property can be used if preferred, the script uses Rich Text). This field is crucial as it stores the unique identifier from Todoist, enabling reliable updates.
--   **`Last Synced`**: This must be a **Date** property. It will be updated each time the project is created or updated.
+-   **`Description`**: This must be a **Rich Text** property. It will store a generated description (e.g., "Contains X comments. Todoist Project ID: YYYYYY.").
+-   **`Todoist ID`**: This must be a **Rich Text** property. This field is crucial as it stores the unique identifier from Todoist, enabling reliable updates.
+-   **`Last Synced`**: This must be a **Date** property. It will be updated each time the project is successfully synced.
 
 **Share the Integration**: You also need to share your Notion integration with the target database:
 1.  Open the Notion database.
@@ -68,70 +73,84 @@ Your Notion database must be configured with the following properties:
 5.  Ensure it has "Can edit content" permissions.
 
 ## Deployment
-This function is designed to be deployed on Google Cloud Functions.
+This function is designed to be deployed on Google Cloud Functions (2nd gen).
 
-1.  **Using `gcloud` CLI**:
-    ```bash
-    gcloud functions deploy sync_projects \
-        --gen2 \
-        --runtime python39 \
-        --region YOUR_REGION \
-        --source . \
-        --entry-point sync_projects \
-        --trigger-http \
-        --allow-unauthenticated \ # Or configure authentication as needed
-        --set-secrets "todoist-api-key=todoist-api-key:latest,notion-api-key=notion-api-key:latest,notion-database-id=notion-database-id:latest" \
-        --service-account YOUR_SERVICE_ACCOUNT_EMAIL
-    ```
-    -   Replace `YOUR_REGION` with your desired GCP region (e.g., `us-central1`).
-    -   Replace `YOUR_SERVICE_ACCOUNT_EMAIL` with the email of the service account that has permissions for Secret Manager.
-    -   The `--set-secrets` flag maps the environment variables used in the code to the secrets stored in Secret Manager.
-    -   The `--allow-unauthenticated` flag makes the function publicly accessible. For production, consider using authenticated invocations.
+### 1. Using `gcloud` CLI (Recommended)
+This method aligns with the automated deployment in `.github/workflows/deploy.yml`.
 
-2.  **Via Google Cloud Console**:
-    -   Navigate to Cloud Functions in the GCP Console.
-    -   Click "Create function".
-    -   Configure the function:
-        -   Environment: 2nd gen
-        -   Function name: e.g., `sync-todoist-to-notion`
-        -   Region: Your preferred region
-        -   Trigger: HTTP, Allow unauthenticated invocations (or set up authentication).
-        -   Runtime, build, connections and security settings:
-            -   Service account: Select a service account with Secret Manager access.
-            -   Under "Runtime environment variables", add references to the secrets:
-                -   `todoist-api-key`: `todoist-api-key:latest` (Select "Secret")
-                -   `notion-api-key`: `notion-api-key:latest` (Select "Secret")
-                -   `notion-database-id`: `notion-database-id:latest` (Select "Secret")
-        -   Runtime: Python 3.9 (or your chosen version)
-        -   Entry point: `sync_projects`
-        -   Source code: Upload a ZIP of the repository or connect to a Cloud Source Repository.
+```bash
+gcloud functions deploy sync-projects \
+    --gen2 \
+    --runtime python311 \
+    --region YOUR_REGION \
+    --source . \
+    --entry-point sync_projects \
+    --trigger-http \
+    --allow-unauthenticated \ # Or configure authentication as needed
+    --set-env-vars GCP_PROJECT=YOUR_GCP_PROJECT_ID \
+    --service-account YOUR_SERVICE_ACCOUNT_EMAIL # Optional: Specify if not using default
+```
+-   Replace `YOUR_REGION` with your desired GCP region (e.g., `us-central1`).
+-   Replace `YOUR_GCP_PROJECT_ID` with your actual Google Cloud Project ID. This is crucial for the function to locate secrets.
+-   Replace `YOUR_SERVICE_ACCOUNT_EMAIL` with the email of the service account that will run the function. This service account needs "Secret Manager Secret Accessor" role for the secrets and any other roles required by Cloud Functions. If you are using the default service account for Cloud Functions, ensure it has the necessary permissions.
+-   The `--allow-unauthenticated` flag makes the function publicly accessible. For production, consider using authenticated invocations.
+-   The function name `sync-projects` is used here, matching the workflow. The entry point in the code is `sync_projects`.
+
+The key difference from previous versions or other common patterns is that API keys are **not** directly passed via `--set-secrets`. Instead, the `GCP_PROJECT` environment variable is passed, and the function code uses this to construct the full resource names for accessing secrets.
+
+### 2. Via Google Cloud Console
+If deploying via the Google Cloud Console:
+-   Navigate to Cloud Functions in the GCP Console.
+-   Click "Create function".
+-   Configure the function:
+    -   Environment: **2nd gen**
+    -   Function name: e.g., `sync-projects`
+    -   Region: Your preferred region
+    -   Trigger: HTTP, Allow unauthenticated invocations (or set up authentication).
+    -   Runtime, build, connections and security settings:
+        -   Under "Runtime environment variables", add:
+            -   Name: `GCP_PROJECT`, Value: `YOUR_GCP_PROJECT_ID` (replace with your actual project ID).
+        -   Service account: Select a service account that has the "Secret Manager Secret Accessor" role for the required secrets.
+    -   Runtime: Python 3.11
+    -   Entry point: `sync_projects`
+    -   Source code: Upload a ZIP of the repository or connect to a Cloud Source Repository.
 
 Refer to the [official Google Cloud Functions deployment documentation](https://cloud.google.com/functions/docs/deploying) for more comprehensive instructions.
 
 ## Usage
 Once deployed, the function can be triggered by sending an HTTP GET or POST request to its assigned URL.
 
--   **Success Response (200 OK)**:
+-   **Success or Partial Success Response (200 OK)**:
     The response message will indicate counts for checked, created, and updated projects.
-    If any non-critical errors occurred during the processing of individual projects, the status might be "partial_success", and the "errors" array in "details" will be populated.
+    If any non-critical errors occurred during the processing of individual projects, the status will be `partial_success`, and the `errors` array in `details` will be populated.
     ```json
     {
-        "status": "success", // or "partial_success" if non-critical errors occurred
-        "message": "Sync complete! Checked: Y, Created: X, Updated: U. Skipped: S. Encountered E error(s).",
+        "status": "success", // or "partial_success"
+        "message": "Sync complete! Checked: Y, Created: X, Updated: U. Encountered E error(s).",
         "details": {
             "checked": Y,
             "created": X,
             "updated": U,
-            "skipped": S, // Should generally be 0 with ID-based matching
-            "errors": [ /* array of error messages for specific projects */ ]
+            "skipped": 0, // This will typically be 0 with the current ID-based matching logic
+            "errors": [ /* array of error messages for specific projects, if any */ ]
         }
     }
     ```
--   **Critical Error Response (500 Internal Server Error)**:
+
+-   **Critical Error Response (4xx or 5xx)**:
+    For critical errors (e.g., `GCP_PROJECT` not configured, major API failures), an appropriate HTTP status code (like 400 or 500) will be returned with a JSON body.
     ```json
     {
         "status": "error",
-        "message": "Description of the error that occurred."
+        "message": "Server configuration error: GCP_PROJECT environment variable not set.",
+        "details": {
+            "checked": 0,
+            "created": 0,
+            "updated": 0,
+            "skipped": 0,
+            "errors": 1,
+            "error_details": ["GCP_PROJECT environment variable not set."]
+        }
     }
     ```
 
@@ -140,35 +159,36 @@ You can use a service like Google Cloud Scheduler to trigger this function on a 
 ## Project Structure
 ```
 .
-├── main.py           # Main Cloud Function logic for syncing.
-├── requirements.txt  # Python dependencies.
-├── README.md         # This file.
-└── .gcloudignore     # Specifies files to ignore during GCP deployment.
-└── src/              # Currently unused, planned for future modularization.
+├── .github/workflows/deploy.yml # GitHub Actions workflow for automated deployment
+├── main.py                      # Main Cloud Function logic for syncing.
+├── requirements.txt             # Python dependencies.
+├── README.md                    # This file.
+└── .gcloudignore                # Specifies files to ignore during GCP deployment.
+└── src/                         # Currently unused, can be used for future modularization.
 ```
+(Other files like `.devcontainer/` might be present for development.)
 
 ## Error Handling and Logging
--   The function logs detailed information, warnings, and errors to Google Cloud Logging. This should be your first point of reference for troubleshooting.
+-   The function logs detailed information, warnings, and errors to Google Cloud Logging (stdout/stderr from `print` statements in `main.py`). This should be your first point of reference for troubleshooting.
 -   **Common Errors**:
-    -   `Secret Manager secret not found or permission denied`: Ensure the secret names are correct and the function's service account has the "Secret Manager Secret Accessor" role.
-    -   `Todoist API error: 401` or `Notion API error: 401`: API key is likely invalid or missing permissions. Verify your API keys.
-    -   `Notion API error: 400` or `404` with database ID: The Notion Database ID might be incorrect, or the integration may not have been shared with the database.
-    -   `ValueError: GCP_PROJECT environment variable not set.`: Usually occurs during local testing if the `GCP_PROJECT` env var isn't set.
-    -   Property mismatch in Notion: If the Notion database properties (`Name`, `Source`, `Description`, `Todoist ID`, `Last Synced`) are not set up exactly as specified, creation or updates will fail. Check the logs for details.
-    -   Missing "Todoist ID" on existing pages: If you have pages created before the "Todoist ID" field was used, they won't be updated. Consider manually backfilling this ID or a one-time script.
+    -   `Secret Manager secret not found or permission denied`: Ensure the secret names are correct (`todoist-api-key`, `notion-api-key`, `notion-database-id`), they exist in the correct `GCP_PROJECT`, and the function's service account has the "Secret Manager Secret Accessor" role.
+    -   `Todoist API error: 401` or `Notion API error: 401`: API key is likely invalid or missing permissions. Verify your API keys in Secret Manager.
+    -   `Notion API error: 400` or `404` with database ID: The Notion Database ID might be incorrect, or the integration may not have been shared with the database with "Can edit content" permissions.
+    -   `Configuration error: GCP_PROJECT environment variable not set.`: This occurs if the `GCP_PROJECT` environment variable is not set for the Cloud Function during deployment.
+    -   Property mismatch in Notion: If the Notion database properties (`Name`, `Source`, `Description`, `Todoist ID`, `Last Synced`) are not set up exactly as specified, creation or updates will fail. Check the logs for details from the Notion API.
+    -   Missing "Todoist ID" on existing Notion pages: If you have pages in Notion created before this sync logic or by other means without the "Todoist ID" field populated, they won't be matched or updated by this script.
 
 ## Future Improvements
--   **Sync More Fields**: Allow synchronization of other project fields like comments (Todoist `comment_count` to Notion description or comments), labels, due dates, etc.
--   **Selective Sync**: Implement filters to sync only specific Todoist projects (e.g., based on a Todoist label or parent project).
--   **Configuration File**: Manage settings like Notion property names and types via a configuration file for more flexibility.
--   **Enhanced Error Resilience**: Implement more sophisticated retry mechanisms for transient network or API rate limit errors.
+-   **Sync More Fields**: Allow synchronization of other Todoist project fields if available and desired (e.g., project color, favorite status, or fetching actual comments to populate Notion comments or enhance the description).
+-   **Selective Sync**: Implement filters to sync only specific Todoist projects (e.g., based on a Todoist label, parent project, or a specific list of project IDs).
+-   **Configuration File/Variables**: Manage settings like Notion property names via environment variables or a configuration file for more flexibility if the database schema changes.
+-   **Enhanced Error Resilience**: Implement more sophisticated retry mechanisms (e.g., exponential backoff) for transient network or API rate limit errors from Todoist or Notion.
 -   **Unit and Integration Tests**: Add a comprehensive test suite to ensure reliability.
--   **Two-Way Sync**: Explore options for bidirectional synchronization (significantly more complex, involves handling potential conflicts and update loops).
--   **Deletion Handling**: Decide how to handle projects deleted in Todoist (e.g., delete in Notion, archive in Notion, or ignore).
+-   **Two-Way Sync**: Explore options for bidirectional synchronization (this is significantly more complex due to potential conflicts and update loops).
+-   **Deletion Handling**: Decide how to handle projects deleted in Todoist (e.g., delete in Notion, archive in Notion, or add a "Deleted from Todoist" status). Currently, they remain in Notion.
 
 ## Contributing
 Contributions are welcome! Please feel free to submit a pull request or open an issue for bugs, feature requests, or improvements.
-(Consider adding more specific guidelines if the project grows, e.g., coding style, branch naming conventions.)
 
 ## License
 This project is released under the MIT License.

--- a/main.py
+++ b/main.py
@@ -1,69 +1,428 @@
-# Let's modify main.py to explore the data structure
+"""
+Synchronizes projects from Todoist to a Notion database.
+
+This script is designed as a Google Cloud Function, triggered via HTTP.
+It fetches projects from a Todoist account and ensures corresponding pages
+exist and are up-to-date in a specified Notion database.
+
+Key Features:
+- Retrieves Todoist projects using the Todoist REST API.
+- Interacts with a Notion database using the Notion API.
+- Securely accesses API keys (Todoist API Key, Notion API Key) and the
+  Notion Database ID from Google Secret Manager.
+- Creates new pages in Notion for Todoist projects not yet present.
+- Updates existing Notion pages if the corresponding Todoist project's details
+  (e.g., name, description generated from comment count) have changed.
+- Uses a "Todoist ID" property in Notion to reliably map Todoist projects
+  to Notion pages.
+- Updates a "Last Synced" timestamp in Notion for each processed project.
+
+The main entry point for the Cloud Function is `sync_projects`.
+"""
 import functions_framework
 import json
 import os
 import requests
 from google.cloud import secretmanager
+from datetime import datetime, timezone
+import traceback # For logging stack traces in unhandled exceptions
 
-def get_todoist_projects():
-    """
-    Fetches Todoist projects using the Todoist REST API.
-    The API key is securely retrieved from Google Secret Manager.
-    Returns a list of project dictionaries as returned by the API.
-    """
-    # Step 1: Set up the name of the secret in Google Secret Manager
-    secret_name = "projects/YOUR_PROJECT_ID/secrets/TODOIST_API_KEY/versions/latest"  # <-- Replace YOUR_PROJECT_ID
+# --- Environment and Secret Configuration ---
+# GCP_PROJECT is expected to be set in the Google Cloud Function environment.
+GCP_PROJECT = os.environ.get('GCP_PROJECT')
 
-    # Step 2: Create a Secret Manager client
+# Secret IDs in Google Secret Manager
+TODOIST_API_KEY_SECRET_ID = "todoist-api-key"
+NOTION_API_KEY_SECRET_ID = "notion-api-key"
+NOTION_DATABASE_ID_SECRET_ID = "notion-database-id"
+
+# --- Notion API Configuration ---
+NOTION_API_VERSION = "2022-06-28"  # Recommended version by Notion documentation
+
+def get_secret(secret_id: str) -> str:
+    """
+    Retrieves a secret's value from Google Secret Manager.
+
+    Args:
+        secret_id: The ID of the secret in Secret Manager (e.g., "todoist-api-key").
+
+    Returns:
+        The secret value as a string.
+
+    Raises:
+        ValueError: If the GCP_PROJECT environment variable is not set.
+        google.api_core.exceptions.GoogleAPIError: If there's an issue accessing
+            the secret (e.g., permission denied, secret not found).
+    """
+    if not GCP_PROJECT:
+        # This is a critical configuration error, as project ID is needed for secret path.
+        raise ValueError("GCP_PROJECT environment variable not set.")
+
     client = secretmanager.SecretManagerServiceClient()
+    # Construct the full secret version name
+    secret_name = f"projects/{GCP_PROJECT}/secrets/{secret_id}/versions/latest"
 
-    # Step 3: Access the secret version and get the API key
-    response = client.access_secret_version(request={"name": secret_name})
-    api_key = response.payload.data.decode("UTF-8")
+    try:
+        response = client.access_secret_version(request={"name": secret_name})
+        return response.payload.data.decode("UTF-8")
+    except Exception as e:
+        # Log the specific secret that failed for easier debugging
+        print(f"Error accessing secret '{secret_id}' in project '{GCP_PROJECT}': {e}")
+        raise # Re-raise the exception to be handled by the calling function or main handler
 
-    # Step 4: Set up the Todoist API endpoint and headers
+def get_todoist_api_key() -> str:
+    """
+    Retrieves the Todoist API key from Secret Manager.
+
+    Returns:
+        The Todoist API key as a string.
+
+    Raises:
+        (propagates exceptions from get_secret)
+    """
+    return get_secret(TODOIST_API_KEY_SECRET_ID)
+
+def get_notion_credentials() -> tuple[str, str]:
+    """
+    Retrieves Notion API key and Database ID from Secret Manager.
+
+    Returns:
+        A tuple containing:
+            - notion_api_key (str): The Notion API key.
+            - notion_database_id (str): The ID of the Notion database.
+
+    Raises:
+        (propagates exceptions from get_secret)
+    """
+    api_key = get_secret(NOTION_API_KEY_SECRET_ID)
+    database_id = get_secret(NOTION_DATABASE_ID_SECRET_ID)
+    return api_key, database_id
+
+def get_todoist_projects(api_key: str) -> list[dict]:
+    """
+    Fetches all projects from Todoist using the Todoist REST API.
+
+    Args:
+        api_key: The Todoist API key.
+
+    Returns:
+        A list of project dictionaries as returned by the Todoist API.
+        Each dictionary represents a project and contains its properties.
+
+    Raises:
+        requests.exceptions.RequestException: If there's an issue with the
+            API request (e.g., network error, non-2xx status code).
+    """
     url = "https://api.todoist.com/rest/v2/projects"
     headers = {
         "Authorization": f"Bearer {api_key}"
     }
-
-    # Step 5: Make the GET request to Todoist API
     response = requests.get(url, headers=headers)
-    response.raise_for_status()  # Raises an error for bad responses
+    response.raise_for_status() # Raises an HTTPError for bad responses (4xx or 5xx)
+    return response.json()
 
-    # Step 6: Parse and return the JSON response (list of projects)
+# --- Notion Helper Functions ---
+
+def query_notion_database(notion_api_key: str, notion_database_id: str, todoist_project_id_str: str) -> list[dict]:
+    """
+    Queries a Notion database to find pages with a specific "Todoist ID".
+
+    Args:
+        notion_api_key: The Notion API key.
+        notion_database_id: The ID of the Notion database to query.
+        todoist_project_id_str: The Todoist Project ID (as a string) to search for
+                                in the "Todoist ID" property of Notion pages.
+
+    Returns:
+        A list of Notion page objects (dictionaries) that match the query.
+        If no matching pages are found, an empty list is returned.
+
+    Raises:
+        requests.exceptions.RequestException: For network issues or API errors.
+    """
+    url = f"https://api.notion.com/v1/databases/{notion_database_id}/query"
+    headers = {
+        "Authorization": f"Bearer {notion_api_key}",
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_API_VERSION,
+    }
+    # Construct the filter payload for querying by the "Todoist ID" property.
+    # This assumes "Todoist ID" is a Rich Text property in Notion.
+    query_filter = {
+        "property": "Todoist ID", # Name of the Notion property
+        "rich_text": {
+            "equals": todoist_project_id_str
+        }
+    }
+    response = requests.post(url, headers=headers, json={"filter": query_filter})
+    response.raise_for_status()
+    return response.json().get("results", []) # "results" key contains the list of pages
+
+def create_notion_page(
+    notion_api_key: str,
+    notion_database_id: str,
+    project_name: str,
+    todoist_project_id_str: str,
+    project_description: str = ""
+) -> dict:
+    """
+    Creates a new page in the specified Notion database.
+
+    Args:
+        notion_api_key: The Notion API key.
+        notion_database_id: The ID of the Notion database where the page will be created.
+        project_name: The name of the project, to be used as the Notion page title.
+        todoist_project_id_str: The Todoist Project ID (as a string) to store.
+        project_description: A description for the project. Defaults to an empty string.
+                             This will be stored in the "Description" property.
+
+    Returns:
+        A dictionary representing the newly created Notion page object.
+
+    Raises:
+        requests.exceptions.RequestException: For network issues or API errors.
+    """
+    url = "https://api.notion.com/v1/pages"
+    headers = {
+        "Authorization": f"Bearer {notion_api_key}",
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_API_VERSION,
+    }
+
+    current_time_iso = datetime.now(timezone.utc).isoformat()
+
+    # Define the properties for the new Notion page according to the database schema.
+    # Ensure these property names and types match your Notion database setup.
+    properties = {
+        "Name": {"title": [{"text": {"content": project_name}}]},
+        "Todoist ID": {"rich_text": [{"text": {"content": todoist_project_id_str}}]},
+        "Source": {"select": {"name": "Todoist"}}, # Assumes a "Select" property named "Source" with an option "Todoist"
+        "Last Synced": {"date": {"start": current_time_iso}},
+        "Description": {"rich_text": [{"text": {"content": project_description or ""}}]} # Ensure description is not None
+    }
+
+    payload = {
+        "parent": {"database_id": notion_database_id},
+        "properties": properties,
+    }
+    response = requests.post(url, headers=headers, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+def update_notion_page(
+    notion_api_key: str,
+    page_id: str,
+    project_name: str,
+    project_description: str = ""
+) -> dict:
+    """
+    Updates an existing page in Notion.
+
+    Currently updates the "Name", "Description", and "Last Synced" properties.
+
+    Args:
+        notion_api_key: The Notion API key.
+        page_id: The ID of the Notion page to update.
+        project_name: The new name for the project.
+        project_description: The new description for the project. Defaults to an empty string.
+
+    Returns:
+        A dictionary representing the updated Notion page object.
+
+    Raises:
+        requests.exceptions.RequestException: For network issues or API errors.
+    """
+    url = f"https://api.notion.com/v1/pages/{page_id}"
+    headers = {
+        "Authorization": f"Bearer {notion_api_key}",
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_API_VERSION,
+    }
+
+    current_time_iso = datetime.now(timezone.utc).isoformat()
+
+    # Define the properties to update.
+    properties = {
+        "Name": {"title": [{"text": {"content": project_name}}]},
+        "Last Synced": {"date": {"start": current_time_iso}},
+        "Description": {"rich_text": [{"text": {"content": project_description or ""}}]} # Ensure description is not None
+    }
+
+    payload = {"properties": properties}
+    response = requests.patch(url, headers=headers, json=payload)
+    response.raise_for_status()
     return response.json()
 
 @functions_framework.http
-def sync_projects(request):
-    """Main function entry point"""
-    try:
-        # First, let's explore what Todoist gives us
-        todoist_projects = get_todoist_projects()
-        
-        # Debug: Let's see the project structure
-        project_info = []
-        for project in todoist_projects[:3]:  # Just first 3 for testing
-            project_info.append({
-                'name': project['name'],
-                'id': project['id'],
-                'parent_id': project.get('parent_id'),
-                'is_favorite': project.get('is_favorite'),
-                'color': project.get('color'),
-                'view_style': project.get('view_style'),
-                # URL would be: https://todoist.com/app/project/{id}
-                'todoist_url': f"https://todoist.com/app/project/{project['id']}"
-            })
-        
-        return {
+def sync_projects(request: functions_framework. também_request) -> tuple[dict, int] | dict:
+    """
+    Main Google Cloud Function entry point for syncing Todoist projects to Notion.
+
+    Triggered by an HTTP request. It fetches projects from Todoist,
+    compares them with entries in a Notion database (matching by "Todoist ID"),
+    and creates or updates Notion pages accordingly.
+
+    Args:
+        request: The HTTP request object provided by Google Cloud Functions.
+                 This function does not use any data from the request body or query parameters.
+
+    Returns:
+        A tuple containing a JSON serializable dictionary and an HTTP status code,
+        or just a JSON serializable dictionary (which defaults to 200 OK).
+        The dictionary summarizes the sync operation, including counts of
+        projects checked, created, updated, and any errors encountered.
+        Example success response:
+        {
             "status": "success",
-            "message": "Exploring Todoist project structure",
-            "sample_projects": project_info,
-            "total_projects": len(todoist_projects)
+            "message": "Sync complete! Checked: 10, Created: 2, Updated: 8. Encountered 0 error(s).",
+            "details": {
+                "checked": 10,
+                "created": 2,
+                "updated": 8,
+                "skipped": 0, // Skipped is currently not used as items are either created or updated
+                "errors": []
+            }
         }
+        Example error response (e.g., config error):
+        {
+            "status": "error",
+            "message": "Server configuration error: GCP_PROJECT environment variable not set.",
+            "details": { ... }
+        }, 500
+    """
+    log_messages = [] # For accumulating log messages during the run
+    status_counts = {"checked": 0, "created": 0, "updated": 0, "skipped": 0, "errors": 0}
+    error_details = [] # For collecting specific error messages for individual projects
+
+    try:
+        # GCP_PROJECT is crucial for accessing secrets.
+        if not GCP_PROJECT:
+            log_messages.append("CRITICAL: GCP_PROJECT environment variable not set.")
+            # This is a server configuration error, preventing secret access.
+            return {
+                "status": "error",
+                "message": "Server configuration error: GCP_PROJECT environment variable not set.",
+                "details": {"checked": 0, "created": 0, "updated": 0, "skipped": 0, "errors": 1, "error_details": ["GCP_PROJECT not set"]}
+            }, 500 # Internal Server Error
+
+        # Retrieve API keys and configuration from Secret Manager
+        todoist_api_key = get_todoist_api_key()
+        notion_api_key, notion_database_id = get_notion_credentials()
         
-    except Exception as e:
+        # Fetch projects from Todoist
+        todoist_projects = get_todoist_projects(todoist_api_key)
+        log_messages.append(f"Fetched {len(todoist_projects)} projects from Todoist.")
+
+        # Process each Todoist project
+        for project in todoist_projects:
+            status_counts["checked"] += 1
+            project_id_str = str(project['id'])
+            project_name = project['name']
+
+            # Todoist API v2 for projects doesn't have a direct 'description' field.
+            # We generate a description based on comment count and project ID,
+            # as the README implies a "Description" field in Notion should be populated.
+            # This can be customized if project comments themselves need to be fetched.
+            comment_count = project.get("comment_count", 0)
+            project_description_text = f"Contains {comment_count} comments. Todoist Project ID: {project_id_str}."
+
+            try:
+                # Check if this Todoist project already exists in Notion
+                existing_pages = query_notion_database(notion_api_key, notion_database_id, project_id_str)
+
+                if existing_pages:
+                    # Project exists, update it
+                    page_id = existing_pages[0]['id'] # Assuming the first result is the one
+
+                    # Potentially, one could compare current_notion_name and current_notion_description
+                    # with project_name and project_description_text to see if an update is truly needed,
+                    # but for simplicity and to ensure "Last Synced" is always updated, we call update.
+                    # current_notion_name = existing_pages[0]['properties']['Name']['title'][0]['text']['content']
+
+                    update_notion_page(notion_api_key, page_id, project_name, project_description_text)
+                    status_counts["updated"] += 1
+                    log_messages.append(f"Updated Notion page for Todoist project: '{project_name}' (ID: {project_id_str})")
+                else:
+                    # Project does not exist, create it
+                    create_notion_page(notion_api_key, notion_database_id, project_name, project_id_str, project_description_text)
+                    status_counts["created"] += 1
+                    log_messages.append(f"Created Notion page for Todoist project: '{project_name}' (ID: {project_id_str})")
+
+            except requests.exceptions.RequestException as re:
+                # Handle errors related to Notion API calls (e.g., network, specific API error codes)
+                status_counts["errors"] += 1
+                # Try to get status code from response, if available
+                status_code_info = f" (Status: {re.response.status_code})" if re.response is not None else ""
+                err_msg = f"API Error processing project '{project_name}' (ID: {project_id_str}){status_code_info}: {str(re)}"
+                error_details.append(err_msg)
+                log_messages.append(f"ERROR: {err_msg}")
+            except Exception as e:
+                # Handle other unexpected errors during individual project processing
+                status_counts["errors"] += 1
+                err_msg = f"Unexpected error processing project '{project_name}' (ID: {project_id_str}): {str(e)}"
+                error_details.append(err_msg)
+                log_messages.append(f"ERROR: {err_msg}")
+                traceback.print_exc() # Log stack trace for unexpected errors
+        
+        final_message = (
+            f"Sync complete! Checked: {status_counts['checked']}, "
+            f"Created: {status_counts['created']}, Updated: {status_counts['updated']}. "
+            # f"Skipped: {status_counts['skipped']}. " # Skipped is not currently used as items are either created or updated
+            f"Encountered {status_counts['errors']} error(s)."
+        )
+        
+        # Print all collected log messages (useful for Cloud Logging)
+        for msg in log_messages:
+            print(msg)
+        if error_details:
+            print("--- Error Details ---")
+            for err in error_details:
+                print(err)
+            print("--- End Error Details ---")
+
+        response_status = "success" if status_counts["errors"] == 0 else "partial_success"
+        http_status_code = 200 # OK for both success and partial_success
+
+        return {
+            "status": response_status,
+            "message": final_message,
+            "details": {
+                "checked": status_counts["checked"],
+                "created": status_counts["created"],
+                "updated": status_counts["updated"],
+                "skipped": status_counts["skipped"], # Will be 0 with current logic
+                "errors": error_details
+            }
+        }, http_status_code
+
+    except ValueError as ve: # Handles GCP_PROJECT not set from get_secret
+        err_msg = f"Configuration error: {str(ve)}"
+        print(err_msg)
         return {
             "status": "error",
-            "message": str(e)
-        }, 500
+            "message": err_msg,
+            "details": {"checked": 0, "created": 0, "updated": 0, "skipped": 0, "errors": 1, "error_details": [str(ve)]}
+        }, 400 # Bad Request, as it's a client-side (configuration) error
+    except requests.exceptions.RequestException as re:
+        # Handles critical errors during initial API calls (e.g., fetching Todoist projects, initial secret retrieval)
+        err_msg = f"A critical API error occurred: {str(re)}"
+        print(err_msg)
+        traceback.print_exc()
+        status_counts["errors"] +=1
+        return {
+            "status": "error",
+            "message": err_msg,
+            "details": {**status_counts, "error_details": error_details + [f"Critical API error: {str(re)}"]}
+        }, 500 # Internal Server Error
+    except Exception as e:
+        # Catch-all for any other unhandled exceptions in the main flow
+        err_msg = f"An unexpected critical error occurred: {str(e)}"
+        print(err_msg)
+        traceback.print_exc() # Log the full stack trace for debugging
+
+        status_counts["errors"] +=1
+        return {
+            "status": "error",
+            "message": err_msg,
+            "details": {**status_counts, "error_details": error_details + [f"Critical unhandled error: {str(e)}"]}
+        }, 500 # Internal Server Error


### PR DESCRIPTION
I restored the core functionality of synchronizing Todoist projects to a Notion database in `main.py`. This includes:
- Fetching projects from Todoist.
- Retrieving API keys and Notion database ID from Google Secret Manager, using the GCP_PROJECT environment variable.
- Querying Notion for existing projects based on a "Todoist ID" custom property.
- Creating new pages in Notion for new Todoist projects or updating existing ones.
- Populating Notion page properties: Name, Source, Description (generated from Todoist project details), Todoist ID, and Last Synced.
- Returning a JSON response summarizing the sync operations.

I added comprehensive documentation to `main.py`:
- Module-level docstring explaining the script's purpose and features.
- Detailed function-level docstrings for all functions, including parameters, return values, and exceptions.
- Inline comments for complex logic.
- Type hints for function signatures and improved logging with tracebacks.

I updated `README.md` to:
- Accurately reflect the restored sync functionality.
- Correct the Python version to 3.11+.
- Align deployment instructions (gcloud CLI and Console) with the current code, particularly the use of the `GCP_PROJECT` environment variable for secret access.
- Update example JSON responses to match the actual output.
- Revise the project structure section.
- Ensure all setup and configuration details are accurate.